### PR TITLE
Stop and start camera session based on x position

### DIFF
--- a/Gaia/ContainerViewController.swift
+++ b/Gaia/ContainerViewController.swift
@@ -8,19 +8,21 @@
 
 import UIKit
 
-class ContainerViewController: UIViewController {
+class ContainerViewController: UIViewController, UIScrollViewDelegate {
 
     // Scroll View
     @IBOutlet weak var scrollView: UIScrollView!
     
+    
+    // Setup Views for Scroll View Container Swipe
+    let ScoreVC :ScoreViewController = ScoreViewController(nibName: "ScoreViewController", bundle: nil)
+    let CatalogueVC :ImageCatalogueViewController = ImageCatalogueViewController(nibName: "ImageCatalogueViewController", bundle: nil)
+    let HomeVC :HomeViewController = HomeViewController(nibName: "HomeViewController", bundle: nil)
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Setup Views for Scroll View Container Swipe
-        let ScoreVC :ScoreViewController = ScoreViewController(nibName: "ScoreViewController", bundle: nil)
-        let CatalogueVC :ImageCatalogueViewController = ImageCatalogueViewController(nibName: "ImageCatalogueViewController", bundle: nil)
-        let HomeVC :HomeViewController = HomeViewController(nibName: "HomeViewController", bundle: nil)
-
+        
         // Add Child Views to Container View Hierarchy
         self.addChildViewController(ScoreVC)
         self.scrollView!.addSubview(ScoreVC.view)
@@ -47,7 +49,26 @@ class ContainerViewController: UIViewController {
         let scrollWidth :CGFloat = 3 * self.view.frame.width
         let scrollHeight : CGFloat = self.view.frame.size.width
         self.scrollView!.contentSize = CGSizeMake(scrollWidth, scrollHeight)
+        
+        scrollView.delegate = self
+        
+    }
+    func scrollViewDidScroll(scrollView: UIScrollView) {
+        
+       let scrollContentOffset = scrollView.contentOffset
+        if(scrollContentOffset.x == 0){
+        
+            HomeVC.session.stopRunning()
+            print("Stopped running session")
+        }else if(scrollContentOffset.x == 322){
+            HomeVC.session.startRunning()
+            print("Session is running")
 
+        }
+        
+        
+        print(scrollContentOffset)
+        
     }
     
     
@@ -57,6 +78,7 @@ class ContainerViewController: UIViewController {
         var frame :CGRect = scrollView.frame
         frame.origin.x = frame.size.width
         scrollView.scrollRectToVisible(frame, animated: false)
+
         
     }
 

--- a/Gaia/ContainerViewController.swift
+++ b/Gaia/ContainerViewController.swift
@@ -13,15 +13,16 @@ class ContainerViewController: UIViewController, UIScrollViewDelegate {
     // Scroll View
     @IBOutlet weak var scrollView: UIScrollView!
     
-    
     // Setup Views for Scroll View Container Swipe
     let ScoreVC :ScoreViewController = ScoreViewController(nibName: "ScoreViewController", bundle: nil)
     let CatalogueVC :ImageCatalogueViewController = ImageCatalogueViewController(nibName: "ImageCatalogueViewController", bundle: nil)
     let HomeVC :HomeViewController = HomeViewController(nibName: "HomeViewController", bundle: nil)
+    
+    // Variables
+    var sessionRunning = false // Flag test for the session running
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         
         // Add Child Views to Container View Hierarchy
         self.addChildViewController(ScoreVC)
@@ -50,24 +51,34 @@ class ContainerViewController: UIViewController, UIScrollViewDelegate {
         let scrollHeight : CGFloat = self.view.frame.size.width
         self.scrollView!.contentSize = CGSizeMake(scrollWidth, scrollHeight)
         
+        // Delegate control of the scrollview
         scrollView.delegate = self
+        
+        // Set session flag
+        sessionRunning = true
         
     }
     func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
         
        let scrollContentOffset = scrollView.contentOffset
-        if(scrollContentOffset.x == 0){
         
+        if((sessionRunning && scrollContentOffset.x == 0) || (sessionRunning && scrollContentOffset.x == 640)) {
+            // View has left the homeview, stop the camera session
             HomeVC.session.stopRunning()
-            print("Stopped running session")
-        }else if(scrollContentOffset.x == 320 && HomeVC.session.isAccessibilityElement){
+            // Broadcast stop of camera
+            self.sessionRunning = false
+            NSLog("Stopped running session\n")
+        }
+        else if(!sessionRunning && scrollContentOffset.x == 320) {
+            // View has returned to homeview, start the camera session
             HomeVC.session.startRunning()
-            print("Session is running")
-
+            // Broadcast start of camera
+            self.sessionRunning = true
+            NSLog("Session is running\n")
         }
         
-        
-        print(scrollContentOffset)
+        // Log position of scrollview window at x
+        NSLog("\(scrollContentOffset)")
         
     }
     

--- a/Gaia/ContainerViewController.swift
+++ b/Gaia/ContainerViewController.swift
@@ -53,14 +53,14 @@ class ContainerViewController: UIViewController, UIScrollViewDelegate {
         scrollView.delegate = self
         
     }
-    func scrollViewDidScroll(scrollView: UIScrollView) {
+    func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
         
        let scrollContentOffset = scrollView.contentOffset
         if(scrollContentOffset.x == 0){
         
             HomeVC.session.stopRunning()
             print("Stopped running session")
-        }else if(scrollContentOffset.x == 322){
+        }else if(scrollContentOffset.x == 320 && HomeVC.session.isAccessibilityElement){
             HomeVC.session.startRunning()
             print("Session is running")
 

--- a/Gaia/HomeViewController.swift
+++ b/Gaia/HomeViewController.swift
@@ -121,6 +121,7 @@ class HomeViewController: UIViewController {
                 
                 //Initiate session
                 session.startRunning()
+            
                 
             }
             else {

--- a/Gaia/ImageCatalogueViewController.swift
+++ b/Gaia/ImageCatalogueViewController.swift
@@ -150,6 +150,8 @@ class ImageCatalogueViewController: UIViewController,UICollectionViewDelegate,UI
                     let portraitImage = UIImage(CGImage: (image?.CGImage)!,scale: 1.0,orientation: UIImageOrientation.Right)
                     
                     cell.cellImageView.image = portraitImage
+                    
+                   
                    // UIImage(CGImage: cgImageRef!,scale: 1.0,orientation: UIImageOrientation.Right)
                 }
             })


### PR DESCRIPTION
The camera session takes a huge strain on the memory for the app, we need to pause it when the user leaves the homeview in order to mitigate this slowdown or else the application will lag considerably.
